### PR TITLE
feat: add --no-cache flag and noCache YAML config

### DIFF
--- a/Docs/Architecture/05-supporting-systems.md
+++ b/Docs/Architecture/05-supporting-systems.md
@@ -34,6 +34,7 @@ flowchart TD
 | `inlineSuppressionTag` | `swiftcpd:ignore` | Comment tag to suppress a region |
 | `maxDuplication` | _(none)_ | Fail if duplication % exceeds this |
 | `baselineFilePath` | `.swift-cpd-baseline.json` | Baseline file location |
+| `noCache` | `false` | Disable tokenization cache |
 | `cacheDirectory` | `.swift-cpd-cache` | Token cache directory |
 
 ### `init` Command — Source Path Discovery
@@ -78,7 +79,9 @@ CacheEntry
 └── normalizedTokens — normalized Token list
 ```
 
-The cache is stored at `.swift-cpd-cache/cache.json` (configurable). I/O operations are offloaded to a `Task.detached` to avoid blocking the actor while the caller awaits the result.
+The cache is stored at `.swift-cpd-cache/cache.json` (configurable via `--cache-dir`). I/O operations are offloaded to a `Task.detached` to avoid blocking the actor while the caller awaits the result.
+
+Caching can be disabled entirely with `--no-cache` or `noCache: true` in the YAML file. When disabled, files are re-tokenized on every run and no cache is read or written.
 
 ---
 

--- a/Docs/CodeBase/01-cli-configuration.md
+++ b/Docs/CodeBase/01-cli-configuration.md
@@ -58,6 +58,7 @@ All numeric arguments are parsed and range-validated here. Boolean flags default
 | `--cross-language` | flag | Include C-family files |
 | `--ignore-same-file` | flag | Skip same-file clones |
 | `--ignore-structural` | flag | Skip Type 3/4 clones |
+| `--no-cache` | flag | Disable tokenization cache |
 | `--cache-dir <path>` | `String` | Cache directory |
 | `--version` | flag | Print version and exit |
 | `--help` | flag | Print help and exit |
@@ -98,6 +99,7 @@ var excludePatterns: [String]
 var inlineSuppressionTag: String?
 var enabledCloneTypes: Set<CloneType>?
 var cacheDirectory: String?
+var noCache: Bool
 ```
 
 ---
@@ -138,6 +140,7 @@ Throws `ConfigurationError` when `paths` is empty after merging.
 | `enabledCloneTypes` | `Set<CloneType>` | all four types |
 | `ignoreSameFile` | `Bool` | `true` |
 | `ignoreStructural` | `Bool` | `true` |
+| `noCache` | `Bool` | `false` |
 | `cacheDirectory` | `String` | `.swift-cpd-cache` |
 
 ---

--- a/Docs/CodeBase/04-pipeline.md
+++ b/Docs/CodeBase/04-pipeline.md
@@ -19,6 +19,7 @@ init(
     minimumTokenCount: Int = 50,
     minimumLineCount: Int = 5,
     cacheDirectory: String = ".swift-cpd-cache",
+    noCache: Bool = false,
     crossLanguageEnabled: Bool = false,
     thresholds: DetectionThresholds = .defaults,
     inlineSuppressionTag: String = "swiftcpd:ignore",
@@ -38,7 +39,9 @@ The method is `async` because file loading is parallelized with Swift concurrenc
 
 ```mermaid
 flowchart TD
-    A["analyze(files:)"] --> B["FileCache.load(from:)"]
+    A["analyze(files:)"] --> NCC{noCache?}
+    NCC -- no --> B["FileCache.load(from:)"]
+    NCC -- yes --> C
     B --> C["async let per file"]
     C --> D["FileHasher.hash"]
     D --> E{Cache hit?}

--- a/Docs/USAGE.md
+++ b/Docs/USAGE.md
@@ -136,6 +136,12 @@ exclude:
   - "**/*.generated.swift"
   - "Sources/MyApp/Discovery/Operators/"
 
+# ── Cache ─────────────────────────────────────────────────────────────────────
+
+# Disable caching of tokenization results.
+# When true, files are re-tokenized on every run and no cache is read or written.
+# noCache: true
+
 # ── Cross-language ────────────────────────────────────────────────────────────
 
 # Also analyze Objective-C/C files (.m, .mm, .h, .c, .cpp).
@@ -199,6 +205,7 @@ Paths on the CLI override `paths:` in the YAML file. When no paths are given, th
 | `--exclude <pattern>` | — | glob | Exclude matching files (repeatable) |
 | `--ignore-same-file` | true | — | Skip clones within one file |
 | `--ignore-structural` | true | — | Skip Type 3 and Type 4 clones |
+| `--no-cache` | false | — | Disable tokenization cache |
 | `--cross-language` | false | — | Include Objective-C/C files |
 | `--suppression-tag <tag>` | `swiftcpd:ignore` | — | Custom suppression comment tag |
 | `--max-duplication <N>` | — | 0–100 | Fail if duplication % exceeds N |
@@ -237,6 +244,9 @@ swift-cpd --cross-language Sources/ ObjcSources/
 
 # Fail CI if duplication exceeds 3%
 swift-cpd --max-duplication 3 Sources/
+
+# Run without cache (useful after changing detection rules)
+swift-cpd --no-cache Sources/
 ```
 
 ---

--- a/Sources/SwiftCPD/CLI/ArgumentParser.swift
+++ b/Sources/SwiftCPD/CLI/ArgumentParser.swift
@@ -8,6 +8,7 @@ struct ArgumentParser: Sendable {
         "--cross-language",
         "--ignore-same-file",
         "--ignore-structural",
+        "--no-cache",
     ]
 
     func parse(_ arguments: [String]) throws -> ParsedArguments {
@@ -70,6 +71,8 @@ extension ArgumentParser {
             result.ignoreSameFile = true
         } else if flag == "--ignore-structural" {
             result.ignoreStructural = true
+        } else if flag == "--no-cache" {
+            result.noCache = true
         }
     }
 

--- a/Sources/SwiftCPD/CLI/Configuration.swift
+++ b/Sources/SwiftCPD/CLI/Configuration.swift
@@ -19,6 +19,7 @@ struct Configuration: Sendable {
     let ignoreSameFile: Bool
     let ignoreStructural: Bool
     let cacheDirectory: String
+    let noCache: Bool
 }
 
 extension Configuration {
@@ -48,6 +49,7 @@ extension Configuration {
         self.ignoreSameFile = parsed.ignoreSameFile || yaml?.ignoreSameFile ?? false
         self.ignoreStructural = parsed.ignoreStructural || yaml?.ignoreStructural ?? false
         self.cacheDirectory = parsed.cacheDirectory ?? ".swift-cpd-cache"
+        self.noCache = parsed.noCache || yaml?.noCache ?? false
 
         let yamlTypes = yaml?.enabledCloneTypes.map { Set($0.compactMap { CloneType(rawValue: $0) }) }
         self.enabledCloneTypes = parsed.enabledCloneTypes ?? yamlTypes ?? Set(CloneType.allCases)

--- a/Sources/SwiftCPD/CLI/HelpText.swift
+++ b/Sources/SwiftCPD/CLI/HelpText.swift
@@ -29,6 +29,7 @@ enum HelpText {
                                  Inline suppression tag (default: swiftcpd:ignore)
           --ignore-same-file     Ignore clones where all fragments are in the same file
           --ignore-structural    Ignore Type-3 and Type-4 clones (structural similarity)
+          --no-cache               Disable caching of tokenization results
           --cross-language       Enable cross-language detection (Swift + Objective-C/C)
           --version              Show version information
           --help                 Show this help message

--- a/Sources/SwiftCPD/CLI/ParsedArguments.swift
+++ b/Sources/SwiftCPD/CLI/ParsedArguments.swift
@@ -24,4 +24,5 @@ struct ParsedArguments: Sendable, Equatable {
     var inlineSuppressionTag: String?
     var enabledCloneTypes: Set<CloneType>?
     var cacheDirectory: String?
+    var noCache: Bool = false
 }

--- a/Sources/SwiftCPD/Configuration/YamlConfiguration.swift
+++ b/Sources/SwiftCPD/Configuration/YamlConfiguration.swift
@@ -15,4 +15,5 @@ struct YamlConfiguration: Sendable, Equatable {
     let enabledCloneTypes: [Int]?
     let ignoreSameFile: Bool?
     let ignoreStructural: Bool?
+    let noCache: Bool?
 }

--- a/Sources/SwiftCPD/Configuration/YamlConfigurationLoader.swift
+++ b/Sources/SwiftCPD/Configuration/YamlConfigurationLoader.swift
@@ -30,7 +30,8 @@ struct YamlConfigurationLoader: Sendable {
                 inlineSuppressionTag: nil,
                 enabledCloneTypes: nil,
                 ignoreSameFile: nil,
-                ignoreStructural: nil
+                ignoreStructural: nil,
+                noCache: nil
             )
         }
 

--- a/Sources/SwiftCPD/Configuration/YamlConfigurationParser.swift
+++ b/Sources/SwiftCPD/Configuration/YamlConfigurationParser.swift
@@ -97,7 +97,8 @@ struct YamlConfigurationParser: Sendable {
             inlineSuppressionTag: scalars["inlineSuppressionTag"],
             enabledCloneTypes: try intArray(for: "enabledCloneTypes", in: arrays),
             ignoreSameFile: try boolValue(for: "ignoreSameFile", in: scalars),
-            ignoreStructural: try boolValue(for: "ignoreStructural", in: scalars)
+            ignoreStructural: try boolValue(for: "ignoreStructural", in: scalars),
+            noCache: try boolValue(for: "noCache", in: scalars)
         )
     }
 

--- a/Sources/SwiftCPD/Pipeline/AnalysisPipeline.swift
+++ b/Sources/SwiftCPD/Pipeline/AnalysisPipeline.swift
@@ -6,6 +6,7 @@ struct AnalysisPipeline: Sendable {
         minimumTokenCount: Int = 50,
         minimumLineCount: Int = 5,
         cacheDirectory: String = ".swift-cpd-cache",
+        noCache: Bool = false,
         crossLanguageEnabled: Bool = false,
         thresholds: DetectionThresholds = .defaults,
         inlineSuppressionTag: String = "swiftcpd:ignore",
@@ -14,6 +15,7 @@ struct AnalysisPipeline: Sendable {
         self.minimumTokenCount = minimumTokenCount
         self.minimumLineCount = minimumLineCount
         self.cacheDirectory = cacheDirectory
+        self.noCache = noCache
         self.crossLanguageEnabled = crossLanguageEnabled
         self.thresholds = thresholds
         self.suppressionScanner = SuppressionScanner(tag: inlineSuppressionTag)
@@ -23,6 +25,7 @@ struct AnalysisPipeline: Sendable {
     let minimumTokenCount: Int
     let minimumLineCount: Int
     let cacheDirectory: String
+    let noCache: Bool
     let crossLanguageEnabled: Bool
     let thresholds: DetectionThresholds
     let enabledCloneTypes: Set<CloneType>
@@ -36,11 +39,16 @@ struct AnalysisPipeline: Sendable {
 
     func analyze(files: [String]) async throws -> PipelineResult {
         let cache = FileCache()
-        await cache.load(from: cacheDirectory)
+
+        if !noCache {
+            await cache.load(from: cacheDirectory)
+        }
 
         let fileTokens = try await processFiles(files, cache: cache)
 
-        await cache.save(to: cacheDirectory)
+        if !noCache {
+            await cache.save(to: cacheDirectory)
+        }
 
         let totalTokens = fileTokens.reduce(0) { $0 + $1.tokens.count }
         let detectors = buildDetectors()

--- a/Sources/SwiftCPD/SwiftCPD.swift
+++ b/Sources/SwiftCPD/SwiftCPD.swift
@@ -196,6 +196,7 @@ extension SwiftCPD {
             minimumTokenCount: configuration.minimumTokenCount,
             minimumLineCount: configuration.minimumLineCount,
             cacheDirectory: configuration.cacheDirectory,
+            noCache: configuration.noCache,
             crossLanguageEnabled: configuration.crossLanguageEnabled,
             thresholds: DetectionThresholds(
                 type3Similarity: configuration.type3Similarity,
@@ -254,6 +255,7 @@ extension SwiftCPD {
               - 2
               - 3
               - 4
+            # noCache: true
             """
 
         do {

--- a/Sources/SwiftCPD/Tokenization/SwiftTokenizer.swift
+++ b/Sources/SwiftCPD/Tokenization/SwiftTokenizer.swift
@@ -80,21 +80,17 @@ extension SwiftTokenizer {
     }
 
     private func classifyIdentifier(_ syntaxToken: TokenSyntax) -> TokenKind {
-        guard
-            let parent = syntaxToken.parent
-        else {
-            return .identifier
-        }
+        if let parent = syntaxToken.parent {
+            if parent.is(IdentifierTypeSyntax.self) || parent.is(MemberTypeSyntax.self) {
+                return .typeName
+            }
 
-        if parent.is(IdentifierTypeSyntax.self) || parent.is(MemberTypeSyntax.self) {
-            return .typeName
-        }
-
-        if parent.is(DeclReferenceExprSyntax.self),
-            let grandparent = parent.parent,
-            grandparent.is(FunctionCallExprSyntax.self)
-        {
-            return .typeName
+            if parent.is(DeclReferenceExprSyntax.self),
+                let grandparent = parent.parent,
+                grandparent.is(FunctionCallExprSyntax.self)
+            {
+                return .typeName
+            }
         }
 
         return .identifier

--- a/Tests/SwiftCPDTests/CLI/ArgumentParserTests.swift
+++ b/Tests/SwiftCPDTests/CLI/ArgumentParserTests.swift
@@ -283,6 +283,20 @@ struct ArgumentParserTests {
         #expect(result.ignoreStructural == false)
     }
 
+    @Test("Given --no-cache flag, when parsing, then noCache is true")
+    func noCacheFlag() throws {
+        let result = try parser.parse(["swift-cpd", "--no-cache", "Sources/"])
+
+        #expect(result.noCache == true)
+    }
+
+    @Test("Given no --no-cache flag, when parsing, then noCache defaults to false")
+    func noCacheDefaultFalse() throws {
+        let result = try parser.parse(["swift-cpd", "Sources/"])
+
+        #expect(result.noCache == false)
+    }
+
     @Test("Given --exclude with pattern, when parsing, then captures exclude pattern")
     func excludeFlag() throws {
         let result = try parser.parse(["swift-cpd", "--exclude", "*.generated.swift", "Sources/"])

--- a/Tests/SwiftCPDTests/CLI/ConfigurationCrossLanguageTests.swift
+++ b/Tests/SwiftCPDTests/CLI/ConfigurationCrossLanguageTests.swift
@@ -32,7 +32,8 @@ struct ConfigurationCrossLanguageTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -69,7 +70,8 @@ struct ConfigurationCrossLanguageTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)

--- a/Tests/SwiftCPDTests/CLI/ConfigurationExcludeTests.swift
+++ b/Tests/SwiftCPDTests/CLI/ConfigurationExcludeTests.swift
@@ -42,7 +42,8 @@ struct ConfigurationExcludeTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -69,7 +70,8 @@ struct ConfigurationExcludeTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)

--- a/Tests/SwiftCPDTests/CLI/ConfigurationIgnoreTests.swift
+++ b/Tests/SwiftCPDTests/CLI/ConfigurationIgnoreTests.swift
@@ -23,7 +23,8 @@ struct ConfigurationIgnoreTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: true,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -50,7 +51,8 @@ struct ConfigurationIgnoreTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: false,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -76,7 +78,8 @@ struct ConfigurationIgnoreTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: true
+            ignoreStructural: true,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -103,7 +106,8 @@ struct ConfigurationIgnoreTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: false
+            ignoreStructural: false,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -147,7 +151,8 @@ struct ConfigurationIgnoreTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: [1, 2],
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -174,7 +179,8 @@ struct ConfigurationIgnoreTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: [1, 2],
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)

--- a/Tests/SwiftCPDTests/CLI/ConfigurationTests.swift
+++ b/Tests/SwiftCPDTests/CLI/ConfigurationTests.swift
@@ -106,7 +106,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -132,7 +133,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -158,7 +160,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -185,7 +188,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -211,7 +215,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -237,7 +242,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -266,7 +272,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -293,7 +300,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -499,7 +507,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: "custom:skip",
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -526,7 +535,8 @@ struct ConfigurationTests {
             inlineSuppressionTag: "custom:skip",
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)

--- a/Tests/SwiftCPDTests/CLI/ConfigurationType3Tests.swift
+++ b/Tests/SwiftCPDTests/CLI/ConfigurationType3Tests.swift
@@ -23,7 +23,8 @@ struct ConfigurationType3Tests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -50,7 +51,8 @@ struct ConfigurationType3Tests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -76,7 +78,8 @@ struct ConfigurationType3Tests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -102,7 +105,8 @@ struct ConfigurationType3Tests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)

--- a/Tests/SwiftCPDTests/CLI/ConfigurationType4Tests.swift
+++ b/Tests/SwiftCPDTests/CLI/ConfigurationType4Tests.swift
@@ -23,7 +23,8 @@ struct ConfigurationType4Tests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)
@@ -50,7 +51,8 @@ struct ConfigurationType4Tests {
             inlineSuppressionTag: nil,
             enabledCloneTypes: nil,
             ignoreSameFile: nil,
-            ignoreStructural: nil
+            ignoreStructural: nil,
+            noCache: nil
         )
 
         let config = try Configuration(from: parsed, yaml: yaml)

--- a/Tests/SwiftCPDTests/Configuration/YamlConfigurationParserTests.swift
+++ b/Tests/SwiftCPDTests/Configuration/YamlConfigurationParserTests.swift
@@ -257,6 +257,7 @@ struct YamlConfigurationParserTests {
             inlineSuppressionTag: swiftcpd:ignore
             ignoreSameFile: true
             ignoreStructural: true
+            noCache: true
             paths:
               - Sources/
             exclude: []
@@ -278,6 +279,7 @@ struct YamlConfigurationParserTests {
         #expect(config.inlineSuppressionTag == "swiftcpd:ignore")
         #expect(config.ignoreSameFile == true)
         #expect(config.ignoreStructural == true)
+        #expect(config.noCache == true)
         #expect(config.paths == ["Sources/"])
         #expect(config.exclude == [])
         #expect(config.enabledCloneTypes == [1, 2])


### PR DESCRIPTION
## Summary

- Add `--no-cache` CLI flag and `noCache` YAML config key to disable tokenization cache
- When enabled, files are re-tokenized on every run and no cache is read or written
- Simplify `classifyIdentifier` to eliminate unreachable guard branch (100% line coverage)

## Type of Change

- [x] feat: A new feature has been added.
- [x] refactor: A code change that neither fixes a bug nor adds a feature.
- [x] test: Addition or correction of tests.
- [x] docs: Changes only to the documentation.

## Invariants Checklist

- [x] Detection is deterministic (same input → same output)
- [x] Source files are never modified (tool is read-only)
- [x] Source locations are accurate (file, line, column)
- [x] No false negatives introduced (previously detected clones are still detected)
- [x] Performance not degraded for large codebases
- [x] Swift 6 Strict Concurrency compatible
- [x] Pipeline stages remain stateless pure transformations

## Pipeline Impact

Which stages are affected?

- [x] CLI / Configuration
- [x] Cache / Baseline

## Testing

- [x] Unit tests added or updated
- [x] Both positive cases (expected clones) and negative cases (false positives to avoid) covered
- [x] All tests pass locally (`swift test`)