### PR TITLE
refactor: extract CacheOptions to reduce AnalysisPipeline init parameters

### DIFF
--- a/Sources/SwiftCPD/Pipeline/AnalysisPipeline.swift
+++ b/Sources/SwiftCPD/Pipeline/AnalysisPipeline.swift
@@ -2,11 +2,15 @@ import Foundation
 
 struct AnalysisPipeline: Sendable {
 
+    struct CacheOptions: Sendable {
+        var directory: String
+        var disabled: Bool = false
+    }
+
     init(
         minimumTokenCount: Int = 50,
         minimumLineCount: Int = 5,
-        cacheDirectory: String = ".swift-cpd-cache",
-        noCache: Bool = false,
+        cache: CacheOptions = CacheOptions(directory: ".swift-cpd-cache"),
         crossLanguageEnabled: Bool = false,
         thresholds: DetectionThresholds = .defaults,
         inlineSuppressionTag: String = "swiftcpd:ignore",
@@ -14,8 +18,7 @@ struct AnalysisPipeline: Sendable {
     ) {
         self.minimumTokenCount = minimumTokenCount
         self.minimumLineCount = minimumLineCount
-        self.cacheDirectory = cacheDirectory
-        self.noCache = noCache
+        self.cache = cache
         self.crossLanguageEnabled = crossLanguageEnabled
         self.thresholds = thresholds
         self.suppressionScanner = SuppressionScanner(tag: inlineSuppressionTag)
@@ -24,8 +27,7 @@ struct AnalysisPipeline: Sendable {
 
     let minimumTokenCount: Int
     let minimumLineCount: Int
-    let cacheDirectory: String
-    let noCache: Bool
+    let cache: CacheOptions
     let crossLanguageEnabled: Bool
     let thresholds: DetectionThresholds
     let enabledCloneTypes: Set<CloneType>
@@ -38,16 +40,16 @@ struct AnalysisPipeline: Sendable {
     private let hasher = FileHasher()
 
     func analyze(files: [String]) async throws -> PipelineResult {
-        let cache = FileCache()
+        let fileCache = FileCache()
 
-        if !noCache {
-            await cache.load(from: cacheDirectory)
+        if !cache.disabled {
+            await fileCache.load(from: cache.directory)
         }
 
-        let fileTokens = try await processFiles(files, cache: cache)
+        let fileTokens = try await processFiles(files, cache: fileCache)
 
-        if !noCache {
-            await cache.save(to: cacheDirectory)
+        if !cache.disabled {
+            await fileCache.save(to: cache.directory)
         }
 
         let totalTokens = fileTokens.reduce(0) { $0 + $1.tokens.count }

--- a/Sources/SwiftCPD/SwiftCPD.swift
+++ b/Sources/SwiftCPD/SwiftCPD.swift
@@ -195,8 +195,10 @@ extension SwiftCPD {
         AnalysisPipeline(
             minimumTokenCount: configuration.minimumTokenCount,
             minimumLineCount: configuration.minimumLineCount,
-            cacheDirectory: configuration.cacheDirectory,
-            noCache: configuration.noCache,
+            cache: AnalysisPipeline.CacheOptions(
+                directory: configuration.cacheDirectory,
+                disabled: configuration.noCache
+            ),
             crossLanguageEnabled: configuration.crossLanguageEnabled,
             thresholds: DetectionThresholds(
                 type3Similarity: configuration.type3Similarity,

--- a/Tests/SwiftCPDTests/Integration/ConfigurationIntegrationTests.swift
+++ b/Tests/SwiftCPDTests/Integration/ConfigurationIntegrationTests.swift
@@ -150,7 +150,7 @@ struct ConfigurationIntegrationTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let pipelineResult = try await pipeline.analyze(files: files)

--- a/Tests/SwiftCPDTests/Integration/DeterminismTests.swift
+++ b/Tests/SwiftCPDTests/Integration/DeterminismTests.swift
@@ -39,7 +39,7 @@ struct DeterminismTests {
         let pipelineA = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheA
+            cache: .init(directory: cacheA)
         )
         let resultA = try await pipelineA.analyze(files: files)
 
@@ -47,7 +47,7 @@ struct DeterminismTests {
         let pipelineB = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheB
+            cache: .init(directory: cacheB)
         )
         let resultB = try await pipelineB.analyze(files: reversed)
 
@@ -119,7 +119,7 @@ struct DeterminismTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let discovery = SourceFileDiscovery(crossLanguageEnabled: false)

--- a/Tests/SwiftCPDTests/Integration/ErrorHandlingIntegrationTests.swift
+++ b/Tests/SwiftCPDTests/Integration/ErrorHandlingIntegrationTests.swift
@@ -111,7 +111,7 @@ struct ErrorHandlingIntegrationTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: files)
@@ -173,7 +173,7 @@ struct ErrorHandlingIntegrationTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 50,
             minimumLineCount: 5,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: files)

--- a/Tests/SwiftCPDTests/Pipeline/AnalysisPipelineMutationTests.swift
+++ b/Tests/SwiftCPDTests/Pipeline/AnalysisPipelineMutationTests.swift
@@ -39,7 +39,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1, .type2, .type3]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1, .type2, .type3]
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 
@@ -66,7 +66,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1]
         )
         let result = try await pipeline.analyze(files: [fileB, fileA])
 
@@ -120,7 +120,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1, .type2]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1, .type2]
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 
@@ -197,7 +197,7 @@ struct AnalysisPipelineMutationTests {
         try cSource.write(toFile: fileB, atomically: true, encoding: .utf8)
 
         let pipeline = AnalysisPipeline(
-            minimumTokenCount: 5, minimumLineCount: 1, cacheDirectory: cacheDir
+            minimumTokenCount: 5, minimumLineCount: 1, cache: .init(directory: cacheDir)
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 
@@ -217,7 +217,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1]
         )
         let result = try await pipeline.analyze(files: [fileZ, fileA])
 
@@ -255,7 +255,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1]
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 
@@ -274,7 +274,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1]
         )
         let result = try await pipeline.analyze(files: [fileA])
 
@@ -310,7 +310,7 @@ struct AnalysisPipelineMutationTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1, .type2]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1, .type2]
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 

--- a/Tests/SwiftCPDTests/Pipeline/AnalysisPipelineSortingTests.swift
+++ b/Tests/SwiftCPDTests/Pipeline/AnalysisPipelineSortingTests.swift
@@ -37,7 +37,7 @@ struct AnalysisPipelineSortingTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1, .type2]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1, .type2]
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 
@@ -73,7 +73,7 @@ struct AnalysisPipelineSortingTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1, .type2]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1, .type2]
         )
         let result = try await pipeline.analyze(files: [fileC, fileA, fileB])
 
@@ -105,7 +105,7 @@ struct AnalysisPipelineSortingTests {
 
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5, minimumLineCount: 1,
-            cacheDirectory: cacheDir, enabledCloneTypes: [.type1]
+            cache: .init(directory: cacheDir), enabledCloneTypes: [.type1]
         )
         let result = try await pipeline.analyze(files: [fileA, fileB])
 
@@ -139,7 +139,7 @@ struct AnalysisPipelineSortingTests {
         try standardDuplicateSource.write(toFile: fileA, atomically: true, encoding: .utf8)
 
         let pipeline = AnalysisPipeline(
-            minimumTokenCount: 5, minimumLineCount: 1, cacheDirectory: cacheDir
+            minimumTokenCount: 5, minimumLineCount: 1, cache: .init(directory: cacheDir)
         )
         let result = try await pipeline.analyze(files: [fileA])
 
@@ -163,7 +163,7 @@ struct AnalysisPipelineSortingTests {
         try source.write(toFile: fileA, atomically: true, encoding: .utf8)
 
         let pipeline = AnalysisPipeline(
-            minimumTokenCount: 5, minimumLineCount: 1, cacheDirectory: cacheDir
+            minimumTokenCount: 5, minimumLineCount: 1, cache: .init(directory: cacheDir)
         )
         let result = try await pipeline.analyze(files: [fileA])
 

--- a/Tests/SwiftCPDTests/Pipeline/AnalysisPipelineTests.swift
+++ b/Tests/SwiftCPDTests/Pipeline/AnalysisPipelineTests.swift
@@ -33,7 +33,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: [fileA, fileB])
@@ -69,7 +69,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let firstRun = try await pipeline.analyze(files: [fileA, fileB])
@@ -108,7 +108,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: [fileA, fileB])
@@ -156,7 +156,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let resultWithSuppression = try await pipeline.analyze(files: [fileA, fileB])
@@ -164,7 +164,7 @@ struct AnalysisPipelineTests {
         let pipelineNoSuppression = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir + "-nosup"
+            cache: .init(directory: cacheDir + "-nosup")
         )
 
         let resultWithout = try await pipelineNoSuppression.analyze(files: [
@@ -203,7 +203,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir,
+            cache: .init(directory: cacheDir),
             crossLanguageEnabled: true
         )
 
@@ -239,7 +239,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir,
+            cache: .init(directory: cacheDir),
             enabledCloneTypes: [.type1, .type2]
         )
 
@@ -276,7 +276,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: [fileZ, fileA])
@@ -315,7 +315,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: [fileA, fileB])
@@ -361,7 +361,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir,
+            cache: .init(directory: cacheDir),
             enabledCloneTypes: [.type3]
         )
 
@@ -386,7 +386,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let result = try await pipeline.analyze(files: [fileA])
@@ -423,7 +423,7 @@ struct AnalysisPipelineTests {
         let pipeline = AnalysisPipeline(
             minimumTokenCount: 5,
             minimumLineCount: 1,
-            cacheDirectory: cacheDir
+            cache: .init(directory: cacheDir)
         )
 
         let runA = try await pipeline.analyze(files: filePaths)

--- a/Tests/SwiftCPDTests/TestSupport/AnalysisHelper.swift
+++ b/Tests/SwiftCPDTests/TestSupport/AnalysisHelper.swift
@@ -15,7 +15,7 @@ func analyzeDirectory(
     let pipeline = AnalysisPipeline(
         minimumTokenCount: minimumTokenCount,
         minimumLineCount: minimumLineCount,
-        cacheDirectory: cacheDir
+        cache: .init(directory: cacheDir)
     )
 
     let pipelineResult = try await pipeline.analyze(files: files)


### PR DESCRIPTION
## Summary

- Extract `CacheOptions` struct to group `directory` and `disabled` into a single parameter, reducing `AnalysisPipeline.init` from 8 to 7 parameters

## Type of Change

- [x] refactor: A code change that neither fixes a bug nor adds a feature.

## Invariants Checklist

- [x] Detection is deterministic (same input → same output)
- [x] Source files are never modified (tool is read-only)
- [x] Source locations are accurate (file, line, column)
- [x] No false negatives introduced (previously detected clones are still detected)
- [x] Performance not degraded for large codebases
- [x] Swift 6 Strict Concurrency compatible
- [x] Pipeline stages remain stateless pure transformations

## Pipeline Impact

Which stages are affected?

- [x] Cache / Baseline

## Testing

- [x] Unit tests added or updated
- [x] All tests pass locally (`swift test`)
- 100% line coverage maintained